### PR TITLE
Let's not pwn the attacker

### DIFF
--- a/powerhub/templates/modulelist.html
+++ b/powerhub/templates/modulelist.html
@@ -13,5 +13,4 @@
     </tr>
     {% endfor %}
     </tbody>
-    </thead>
 </table>

--- a/powerhub/upload.py
+++ b/powerhub/upload.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from operator import itemgetter
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 upload_dir = os.path.join(BASE_DIR, "upload")
 
@@ -13,8 +14,8 @@ def save_file(file):
 
     If it already exists, append a counter.
     """
-    filename = os.path.join(upload_dir, str(file.filename))
-    if os.path.isfile(filename):
+    filename = os.path.join(upload_dir, os.path.basename(file.filename))
+    if os.path.exists(filename):
         count = 1
         while os.path.isfile("%s.%d" % (filename, count)):
             count += 1


### PR DESCRIPTION
Upload feature allowed unrestricted file upload by sending `../../../var/www/html/webshell.php` as a filename.

However, exploitability is rather unrealistic in the context of this tool. :wink: But staying with best practices is still great :)

(Besides, fixed malformed HTML)