### PR TITLE
file exchange: added download all functionality

### DIFF
--- a/powerhub/templates/fileexchange.html
+++ b/powerhub/templates/fileexchange.html
@@ -28,6 +28,9 @@
     <input type=submit value=Upload class="submitButton btn btn-primary">
   </div>
 </form>
+<div class="text-right">
+    <a href="/d-all" class="btn btn-secondary btn-sm"><span class="align-baseline" data-feather="download"></span> Download all</a>
+</div>
 </p>
 <div class="container">
 {% if files %}


### PR DESCRIPTION
Since the Hub aids in collaborating within a pentesting team, we thought it would be great if we can download a zip of all the files uploaded within the file exchange functionality. In the end, this can be used to make sure everyone has all the raw data.

So I implemented a "download all" functionality. This is what it looks like

![download-all](https://user-images.githubusercontent.com/5670236/58983456-23cf0900-87d7-11e9-82f0-93085ce6b31e.png)
