### PR TITLE
improved layout of file upload

### DIFF
--- a/powerhub/templates/fileexchange.html
+++ b/powerhub/templates/fileexchange.html
@@ -15,24 +15,23 @@
         </a>
     </sup>
 </h2>
-<div class="row">
-<form action="u" method="POST" enctype="multipart/form-data"
-    class="col-sm-auto">
-  <div class="form-group">
-    <label class="btn btn-default btn-file">
-        <input value="file"
-               name="file[]"
-               type="file"
-               multiple="multiple"
-               class="form-control-file"
-               id="exampleFormControlFile1">
-    </label>
-    <input type=submit value=Upload class="submitButton btn btn-primary btn-sm">
+<div class="row mb-4">
+  <form action="u" method="POST" enctype="multipart/form-data"
+        class="col-sm-auto form-inline">
+    <div class="form-group">
+      <input value="file"
+             name="file[]"
+             type="file"
+             multiple="multiple"
+             class="form-control-file btn btn-default btn-file btn-sm" />
+    </div>
+    <div class="form-group">
+      <input type=submit value=Upload class="submitButton btn btn-primary btn-sm" />
+    </div>
+  </form>
+  <div class="col-sm text-right">
+      <a href="/d-all" class="btn btn-secondary btn-sm flush-right"><span class="align-baseline" data-feather="download"></span> Download all</a>
   </div>
-</form>
-<div class="col-sm text-right">
-    <a href="/d-all" class="btn btn-secondary btn-sm flush-right"><span class="align-baseline" data-feather="download"></span> Download all</a>
-</div>
 </div>
 </p>
 <div class="container">


### PR DESCRIPTION
I further improved the layout of the file upload. Browse button is now also smaller. Upload button is less off now. This more or less happened automatically while refactoring the HTML structure along with the use of Bootstrap's classes.

![fileupload-layout](https://user-images.githubusercontent.com/5670236/59042655-284cfd80-887b-11e9-9966-c14b58346ca6.png)
