### PR TITLE
Some fixes

### DIFF
--- a/powerhub/auth.py
+++ b/powerhub/auth.py
@@ -1,9 +1,10 @@
 from functools import wraps
+
 from flask import request, Response
+
 from powerhub.args import args
 from powerhub.tools import generate_random_key
-import logging
-log = logging.getLogger(__name__)
+from powerhub.logging import log
 
 
 if not (args.AUTH or args.NOAUTH):

--- a/powerhub/clipboard.py
+++ b/powerhub/clipboard.py
@@ -1,6 +1,4 @@
 from sqlalchemy.exc import OperationalError
-import logging
-log = logging.getLogger(__name__)
 
 
 def init_clipboard(db=None):

--- a/powerhub/flask.py
+++ b/powerhub/flask.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
 from datetime import datetime
+import logging
 import os
 import shutil
 from tempfile import TemporaryDirectory
@@ -27,9 +28,8 @@ from powerhub.repos import repositories, install_repo
 from powerhub.obfuscation import symbol_name
 from powerhub.receiver import ShellReceiver
 from powerhub.args import args
+from powerhub.logging import log
 
-import logging
-log = logging.getLogger(__name__)
 
 _db_filename = os.path.join(XDG_DATA_HOME, "powerhub_db.sqlite")
 

--- a/powerhub/logging.py
+++ b/powerhub/logging.py
@@ -1,0 +1,16 @@
+import logging
+import sys
+
+from powerhub.args import args
+
+
+FORMAT = '%(asctime)-15s %(message)s'
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.DEBUG if args.DEBUG else logging.INFO,
+    format=FORMAT,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+log = logging.getLogger(__name__)

--- a/powerhub/powerhub.py
+++ b/powerhub/powerhub.py
@@ -1,30 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import threading
+import signal
+
 import powerhub.flask
 import powerhub.reverseproxy
 from powerhub.args import args
+from powerhub.logging import log
 try:
     from powerhub.webdav import run_webdav
 except ImportError as e:
     print(str(e))
     print("You have unmet dependencies. WebDAV won't be available. "
           "Consult the README.")
-import threading
-import sys
-import signal
-import logging
-
-
-FORMAT = '%(asctime)-15s %(message)s'
-
-logging.basicConfig(
-    stream=sys.stdout,
-    level=logging.DEBUG if args.DEBUG else logging.INFO,
-    format=FORMAT,
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-log = logging.getLogger(__name__)
 
 
 def signal_handler(sig, frame):

--- a/powerhub/receiver.py
+++ b/powerhub/receiver.py
@@ -7,10 +7,9 @@ import struct
 import threading
 from datetime import datetime as dt
 import email.utils as eut
-from powerhub.directories import XDG_DATA_HOME
 
-import logging
-log = logging.getLogger(__name__)
+from powerhub.directories import XDG_DATA_HOME
+from powerhub.logging import log
 
 T_JSON = 0
 T_DICT = 1

--- a/powerhub/reverseproxy.py
+++ b/powerhub/reverseproxy.py
@@ -15,9 +15,7 @@ from twisted.web.resource import Resource
 
 from powerhub.args import args
 from powerhub.tools import get_self_signed_cert
-
-import logging
-log = logging.getLogger(__name__)
+from powerhub.logging import log
 
 
 class DynamicProxy(Resource):

--- a/powerhub/reverseproxy.py
+++ b/powerhub/reverseproxy.py
@@ -37,7 +37,7 @@ class DynamicProxy(Resource):
         for header in [
             ('X-Forwarded-For', x_forwarded_for),
             ('X-Forwarded-Host', x_for_host),
-            ('X-Forwarded-Port', x_for_port),
+            ('X-Forwarded-Port', str(x_for_port)),
             ('X-Forwarded-Proto', x_for_proto),
         ]:
             request.requestHeaders.addRawHeader(*header)

--- a/powerhub/templates/clipboard.html
+++ b/powerhub/templates/clipboard.html
@@ -4,11 +4,11 @@
 {% block content %}
 <p>
 <h2>Clipboard
-<sup>
-<a href="#" title="What's this?" data-toggle="popover"
-data-trigger="focus" data-content="This is the Clipboard. It's like a
-non-persistent guestbook for transfering small code snippets, passwords,
-    hashes, and so forth."><span data-feather="help-circle"></span></a>
+    <sup>
+        <a href="#" title="What's this?" data-toggle="popover"
+        data-trigger="focus" data-content="This is the Clipboard. It's for
+        transfering small code snippets, passwords, hashes, and so forth.">
+        <span data-feather="help-circle"></span></a>
     </sup>
 </h2>
     <div class="col">

--- a/powerhub/tools.py
+++ b/powerhub/tools.py
@@ -1,4 +1,3 @@
-from powerhub.directories import XDG_DATA_HOME
 import io
 import gzip
 import os
@@ -6,8 +5,9 @@ import random
 import string
 
 from OpenSSL import crypto
-import logging
-log = logging.getLogger(__name__)
+
+from powerhub.directories import XDG_DATA_HOME
+from powerhub.logging import log
 
 
 def create_self_signed_cert(hostname,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ wsgidav>=3.0.0
 watchdog
 twisted>=18.9.0
 flask-sqlalchemy>=2.1
+pyOpenSSL
+service_identity


### PR DESCRIPTION
Fixed a few things:

- requirements: Import error due to missing `pyOpenSSL` and warning due to missing `service_identity`
- logging: Introduced `powerhub.logging` for common logging configuration. Prior to that, logging the auto generated basic auth password did not work, because at this time, logging configuration was not yet adjusted to info level.
- twisted: Converted `x_for_port` to string because twisted crashed otherwise (may be due to a change in twisted 19)