### PR TITLE
Fixed typo in Unmount-Webdav abbreviation

### DIFF
--- a/powerhub/templates/powershell/powerhub.ps1
+++ b/powerhub/templates/powershell/powerhub.ps1
@@ -785,7 +785,7 @@ The following functions are available (some with short aliases):
   * Run-Shellcode (rsh)
   * PushTo-Hub (pth)
   * Mount-Webdav (mwd)
-  * Unmount-Webdav (uwd)
+  * Unmount-Webdav (umwd)
 
 Use 'Get-Help' to learn more about those functions.
 "@


### PR DESCRIPTION
Fixed typo in Unmount-Webdav abbreviation: `umwd` instead of `uwd`.