### PR TITLE
Static Files List View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ tests/helpers/test_config.py
 *.pem
 *.pyc
 __pycache__
+*.egg-info
 .tox

--- a/powerhub/app.py
+++ b/powerhub/app.py
@@ -88,7 +88,7 @@ class PowerHubApp(object):
     def init_flask(self):
         from powerhub.flask import app as flask_blueprint
         from powerhub.directories import DB_FILENAME
-        self.flask_app = Flask(__name__)
+        self.flask_app = Flask(__name__, static_url_path='/invalid')
         self.flask_app.register_blueprint(flask_blueprint)
         self.flask_app.wsgi_app = ProxyFix(
             self.flask_app.wsgi_app,

--- a/powerhub/flask.py
+++ b/powerhub/flask.py
@@ -499,6 +499,27 @@ def reload_modules():
     return ('OK', 200)
 
 
+@app.route('/list-static')
+@requires_auth
+def list_static():
+    def get_dir(dir_name):
+        directory = {'name': os.path.basename(dir_name), 'files': [], 'subdirs': []}
+        with os.scandir(dir_name) as it:
+            for x in it:
+                if x.is_file():
+                    directory['files'].append(x.name)
+                if x.is_dir():
+                    subdir = get_dir(os.path.join(dir_name, x.name))
+                    directory['subdirs'].append(subdir)
+        directory['files'].sort()
+        directory['subdirs'].sort(key=lambda x: x['name'])
+        return directory
+    context = {
+        'rootdir': get_dir(STATIC_DIR)
+    }
+    return render_template('list-static.html', **context)
+
+
 @app.route('/static/<path:filename>')
 def server_static(filename):
     try:

--- a/powerhub/flask.py
+++ b/powerhub/flask.py
@@ -499,7 +499,7 @@ def reload_modules():
     return ('OK', 200)
 
 
-@app.route('/static/<filename>')
+@app.route('/static/<path:filename>')
 def server_static(filename):
     try:
         return send_from_directory(STATIC_DIR,

--- a/powerhub/templates/helpstrings.jinja2
+++ b/powerhub/templates/helpstrings.jinja2
@@ -33,3 +33,8 @@ directory (<code>$XDG_DATA_HOME/powerhub/upload/</code> by default)." %}
 {% set clipboard_main = "This is the Clipboard. It's for transfering small
 code snippets, passwords, hashes, and so forth. You can also configure the
 launcher to automatically execute contents of a particular clipboard entry." %}
+
+{% set liststatic_main = "This is the Static Files List. PowerHub serves files
+from your workspace directory (<code>$XDG_DATA_HOME/powerhub/static/</code>
+by default). This page lists your static files and allows you to copy the URL
+conveniently." %}

--- a/powerhub/templates/index.html
+++ b/powerhub/templates/index.html
@@ -73,6 +73,10 @@
       <a class="nav-link {% block fileexchange_active %}{% endblock %}"
          href="/fileexchange">File Exchange</a>
     </li>
+    <li class="nav-item">
+      <a class="nav-link {% block liststatic_active %}{% endblock %}"
+         href="/list-static">Static Files</a>
+    </li>
   </ul>
 </nav>
 

--- a/powerhub/templates/list-static.html
+++ b/powerhub/templates/list-static.html
@@ -1,0 +1,34 @@
+{% extends "index.html" %}
+{% block liststatic_active %}active{% endblock %}
+{% block liststatic_selected %}selected{% endblock %}
+
+{% macro dir_list(dir, prefix) %}
+<ul style="list-style-type: none">
+{% for file in dir.files %}
+    <li><span data-feather="file"></span> <a href="{{ prefix }}/{{ file }}" target="_blank">{{ file }}</a></li>
+{% endfor %}
+{% for subdir in dir.subdirs %}
+    <li><span data-feather="folder"></span> {{ subdir.name }}/
+        {{ dir_list(subdir, prefix+"/"+subdir.name) }}
+    </li>
+{% endfor %}
+</ul>
+{% endmacro %}
+
+{% block content %}
+<p>
+<h2>Static Files
+    <sup>
+        <a href="#"
+           title="What's this?"
+           data-toggle="popover"
+           data-trigger="focus"
+           data-html="true"
+           data-content="{{help.liststatic_main}}">
+           <span data-feather="help-circle"></span>
+        </a>
+    </sup>
+</h2>
+{{ dir_list(rootdir, "static") }}
+</p>
+{% endblock %}

--- a/tests/test_powerhub.py
+++ b/tests/test_powerhub.py
@@ -23,7 +23,7 @@ def flask_app():
     from powerhub.app import PowerHubApp
     app = PowerHubApp([TEST_URI, '--no-auth'])
     from powerhub.flask import app as blueprint
-    flask_app = flask.Flask(__name__, template_folder="../powerhub/templates")
+    flask_app = flask.Flask(__name__, static_url_path='/invalid', template_folder="../powerhub/templates")
     flask_app.register_blueprint(blueprint)
     flask_app = flask_app.test_client()
     yield flask_app


### PR DESCRIPTION
First of all, this makes the `/static/<filename>` endpoint also serve files from subdirectories.
Unfortunately, Flask handels `@app.route('/static/<path:filename>')` internally by default, so my change lead to weird 404 issues. As a workaround, I'm setting `Flask(__name__, static_url_path='/invalid')` when initializing Flask, which avoids the default handling of `static/<path:filename>`. PowerHub explicitly handels `/static` itself anyway.

Now the actual feature I'm contributing is a new view that lists the contents of the `static` directory. This is useful because you do not need to go into your file system to see what you have there. And it is easy to open individual files via link click and copy the URL.

This is what it looks like:
![static-list-view](https://user-images.githubusercontent.com/5670236/143690486-f637ad1d-d9d9-4c65-b78f-e620ba577e92.png)
