### PR TITLE
readme: do not use --user for pip when installing within a virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ venv
 python3-venv`.
 
 Run `python3 -m venv env` to create a virtual environment, then use `source
-env/bin/activate` to activate it. Now run `pip3 install --user .`
+env/bin/activate` to activate it. Now run `pip3 install .`
 to install the depencendies inside the virtual environment.
 
 pipenv


### PR DESCRIPTION
The README stated to use `pip install --user .` within a virtualenv. Specifying `--user` is not necessary and can produce an error.

(Side note: Even outside of a virtualenv it is no longer necessary to specify `--user` since pip defaults to this since a few versions.)