### PR TITLE
help-powerhub: fixed formatting

### DIFF
--- a/powerhub/templates/powershell/powerhub.ps1
+++ b/powerhub/templates/powershell/powerhub.ps1
@@ -916,9 +916,10 @@ The following functions are available (some with short aliases):
   * Update-HubModules (uhm)
   * Get-SysInfo
   * Run-DotNETExe (rdne)
-{% if not minimal %} * Run-Exe (re)
+{%- if not minimal %}
+  * Run-Exe (re)
   * Run-Shellcode (rsh)
-{%- endif -%}
+{%- endif %}
   * PushTo-Hub (pth)
   * Mount-Webdav (mwd)
   * Unmount-Webdav (umwd)


### PR DESCRIPTION
Tested the 2.0 branch and the formatting of the `help-powerhub` output was wrongly aligned. Jinja whitespace...