### PR TITLE
Fixed debug output containing powershell version

### DIFF
--- a/powerhub/templates/powershell/stage1.ps1
+++ b/powerhub/templates/powershell/stage1.ps1
@@ -7,7 +7,7 @@
 
 {{'$DebugPreference = "Continue"'|debug}}
 {{'Write-Debug "Starting up..."'|debug}}
-{{'Write-Debug "PowerShell Version: $PSVersionTable"'|debug}}
+{{'Write-Debug "PowerShell Version: $($PSVersionTable.PSVersion)"'|debug}}
 {{('Write-Debug "PowerHub Version: ' + VERSION + '"')|debug}}
 {%- include "powershell/rc4.ps1" -%}
 


### PR DESCRIPTION
Prior to this change, the debug output contained the `$PSVersionTable` data type instead of the actual version string:

```
DEBUG: PowerShell Version: System.Collections.Hashtable
```
