### PR TITLE
Fixed startup failure and cryptography warning

### DIFF
--- a/powerhub/dhkex.py
+++ b/powerhub/dhkex.py
@@ -19,7 +19,7 @@ def generate_diffie_hellman_params():
     log.info("Generating new Diffie-Hellman parameters")
     g = 2
     parameters = dh.generate_parameters(generator=g, key_size=KEY_SIZE)
-    p = parameters.parameter_numbers()._p
+    p = parameters.parameter_numbers().p
 
     global DH_MODULUS, DH_G
     DH_MODULUS, DH_G = p, g

--- a/powerhub/tools.py
+++ b/powerhub/tools.py
@@ -74,7 +74,7 @@ def get_self_signed_cert(hostname, cert_dir):
     pem_data = open(cert_file, "br").read()
     cert = x509.load_pem_x509_certificate(pem_data, default_backend())
 
-    if cert.not_valid_after < datetime.datetime.now():
+    if cert.not_valid_after_utc < datetime.datetime.now(tz=datetime.timezone.utc):
         log.info("Certificate expired, generating a new one...")
         create_self_signed_cert(hostname, cert_file, key_file)
         pem_data = open(cert_file, "br").read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     'cheroot',
-    'cryptography>=35',
+    'cryptography>=42',
     'dnspython>=2.3',
     'Flask>=1.0.2',
     'Flask-SocketIO>=5.3.0',


### PR DESCRIPTION
Some things changed in cryptography 42.0.0:

1. More of the cryptographic code was ported to Rust and apparently the `DHPublicNumbers._p` attribute is gone now. One should use `DHPublicNumbers.p` instead, which the first commit does. Fortunately, `.p` was already present as a property function, so this is still compatible with older cryptography versions.

2. `x509.Certificate.not_valid_before` has been deprecated and `x509.Certificate.not_valid_before_utc` was introduced instead. This appears to be part of a larger undertaking in the Python ecosystem to enforce the usage of timezone aware datetime objects. I also saw this happen in the standard library. While the fix is easy and still compatible with older Python versions, the minimum required version of cryptography needs to be bumped because the newer attribute was only recently introduced in cryptography 42.0.0. But I don't see this being a real problem when installing PowerHub via pip.

fixes #64