### PR TITLE
Added support for cloning multiple module repos

### DIFF
--- a/powerhub/repos.py
+++ b/powerhub/repos.py
@@ -39,7 +39,7 @@ def install_repo_from_url(url):
 def git_clone(url):
     """Installs a git repository"""
     repo_name = url.split("/")[-1].split(".")[0]
-    dest_dir = directories.MOD_DIR + "/" + repo_name
+    dest_dir = os.path.join(directories.MOD_DIR, repo_name)
     proc = subprocess.run(
         ['git', 'clone', '--depth', '1', url, dest_dir],
         stderr=subprocess.PIPE,

--- a/powerhub/repos.py
+++ b/powerhub/repos.py
@@ -38,7 +38,8 @@ def install_repo_from_url(url):
 
 def git_clone(url):
     """Installs a git repository"""
-    dest_dir = directories.MOD_DIR
+    repo_name = url.split("/")[-1].split(".")[0]
+    dest_dir = directories.MOD_DIR + "/" + repo_name
     proc = subprocess.run(
         ['git', 'clone', '--depth', '1', url, dest_dir],
         stderr=subprocess.PIPE,


### PR DESCRIPTION
Currently it is not possible to add more than one git repository to the PowerHub modules as the `git clone` command clones the repository directly into the modules folder.
This commit clones the repository into a separate subfolder, therefore allowing to users to add multiple repositories.