### PR TITLE
Allow explicitly unsetting the proxy and disable spellcheck on cradle

### DIFF
--- a/powerhub/parameters.py
+++ b/powerhub/parameters.py
@@ -168,6 +168,14 @@ params = [
         get_arg='t',
     ),
     Parameter(
+        'proxy', 'unspecified', 'Web Proxy', 'selection',
+        options=[
+            ("unspecified", "Unspecified (Net.WebClient default behavior)"),
+            ("system_proxy", "System Proxy with Default Credentials"),
+            ("unset", "Explicitly Unset"),
+        ],
+    ),
+    Parameter(
         'kex', 'oob', 'Key Exchange', 'selection',
         options=[
             ("oob", "Out of Band"),
@@ -220,7 +228,6 @@ params = [
         help="By default, PowerShell sets no or a revealing user-agent. "
              "This option sets a more natural user-agent.",
     ),
-    Parameter('proxy', False, 'Use Web Proxy', 'checkbox'),
     Parameter('tlsv1.2', False, 'Force TLSv1.2', 'checkbox',
               classes='relevant-to-https'),
     Parameter(

--- a/powerhub/stager.py
+++ b/powerhub/stager.py
@@ -65,10 +65,12 @@ def build_cradle_webclient(params, key, callback_urls, incremental=False):
 
     result = "$%(web_client)s=New-Object Net.WebClient;"
 
-    if params['proxy']:
+    if params['proxy'] == 'system_proxy':
         result += ("$%(web_client)s.Proxy=[Net.WebRequest]::GetSystemWebProxy();"
                    "$%(web_client)s.Proxy.Credentials=[Net.CredentialCache]::"
                    "DefaultCredentials;")
+    elif params['proxy'] == 'unset':
+        result += ("$%(web_client)s.Proxy=$null;")
 
     if params['useragent']:
         result += (

--- a/powerhub/templates/html/hub/download-cradle.html
+++ b/powerhub/templates/html/hub/download-cradle.html
@@ -1,6 +1,6 @@
 {% if dl_str %}
     <p>Paste this in your launcher (PowerShell/CMD/Bash command):</p>
-    <div class="code_div mb-3" contenteditable='true'>
+    <div class="code_div mb-3" contenteditable='true' spellcheck='false'>
         <code id='dlcradle' data-flavor="hub">{{ dl_str|safe }}</code>
     </div>
 {% else %}


### PR DESCRIPTION
This PR adds two commits.

1. Disable the browser's spell-checking on the download cradle code. This makes no sense, is ugly and distracted me multiple times. See also the screenshot in PowerHub's README which shows the ugly underlining from spell-checking. I recommend doing a new screenshot. :stuck_out_tongue_winking_eye: 

2. I encountered a case where the stager could not connect to PowerHub due to a restrictive proxy. A call by `curl.exe` succeeded, which did not use any proxy. Ticking/unticking the "Use Web Proxy" checkbox did not make any difference. Apparently, the default behavior of `Net.WebClient` was already to use the proxy. This did only happen in the context of a newly created local administrator account. The PowerShell instance of a low-privileged AD user did not use the proxy. Anyway, I was in need to explicitly unset the web proxy. To make this easier, I added an option to the web proxy setting.

Not sure if you like it, since the setting is also possible via a small manual change and it turns the checkbox into a selection field. However, if you decide to not merge this, at least cherry-pick the first commit, because did I say it's ugly? :grin: 