### PR TITLE
Add pivot support

### DIFF
--- a/powerhub/flask.py
+++ b/powerhub/flask.py
@@ -17,7 +17,7 @@ import powerhub.modules as phmod
 from powerhub.upload import save_file, get_filelist
 from powerhub.directories import directories
 from powerhub.payloads import create_payload
-from powerhub.tools import decrypt_aes
+from powerhub.tools import decrypt_aes, modify_callbacks
 from powerhub.repos import repositories, install_repo
 from powerhub.hiddenapp import hidden_app
 from powerhub.dhkex import DH_ENDPOINT, dh_kex
@@ -152,7 +152,9 @@ def dlcradle():
         'cmd_enc',
         'bash',
     ]:
-        cmd = build_cradle(params, app.key, app.callback_urls)
+
+        callbacks = modify_callbacks(app.callback_urls, param_collection["pivot"], app.args)
+        cmd = build_cradle(params, app.key, callbacks)
         href = None
     else:
         # Return a download button for payload

--- a/powerhub/hiddenapp.py
+++ b/powerhub/hiddenapp.py
@@ -6,7 +6,7 @@ import string
 
 from flask import render_template, request, Response, Flask
 
-from powerhub.tools import encrypt_rc4, encrypt_aes, compress
+from powerhub.tools import encrypt_rc4, encrypt_aes, compress, modify_callbacks
 import powerhub.modules as phmod
 from powerhub.stager import get_stage, insert_decoys
 from powerhub.directories import directories
@@ -50,11 +50,12 @@ def get_stage3():
     else:
         webdav_user, webdav_pass = '', ''
 
+    callbacks = modify_callbacks(hidden_app.callback_urls, param_collection['pivot'], hidden_app.args)
     powerhub_context = dict(
         modules=phmod.modules,
         preloaded_modules=preloaded_modules,
         preloaded_modules_content=preloaded_modules_content,
-        callback_url=hidden_app.callback_urls[transport],
+        callback_url=callbacks[transport],
         transport=transport,
         webdav_url=hidden_app.webdav_url,
         webdav_user=webdav_user,
@@ -135,11 +136,12 @@ def stager():
     else:
         separator = ''
 
+    callbacks = modify_callbacks(hidden_app.callback_urls, param_collection['pivot'], hidden_app.args)
     stager_context = dict(
         VERSION=__version__,
         key=key,
         amsibypass=amsi_bypass,
-        callback=hidden_app.callback_urls[transport],
+        callback=callbacks[transport],
         kex=kex,
         DH_G=DH_G,
         DH_MODULUS=DH_MODULUS,

--- a/powerhub/parameters.py
+++ b/powerhub/parameters.py
@@ -192,6 +192,10 @@ params = [
              "Only makes sense with key exchange 'embedded'."
     ),
     Parameter(
+        "pivot", '', 'Pivot', 'text', get_arg='pivot',
+        help="Enter IP of pivot endpoint via which traffic is forwarded to the acutal PowerHub host (e.g. 10.10.10.35:1337). If port is omitted, the original port will be used."
+    ),
+    Parameter(
         'minimal', False, 'Minimal Mode', 'checkbox', get_arg='m',
         help=(
             "In minimal mode, comment-based help of Cmdlets and some obviously "

--- a/powerhub/tools.py
+++ b/powerhub/tools.py
@@ -223,3 +223,36 @@ class Memoize:
         if args not in self.memo:
             self.memo[args] = self.f(*args)
         return self.memo[args]
+
+
+def modify_callbacks(callbacks, pivot_endpoint, args):
+    """Modify callbacks to the given pivot endpoint"""
+
+    def old_port(transport, args):
+        if args.URI_PORT:
+            return args.URI_PORT
+
+        return args.SSL_PORT if transport == "https" else args.LPORT
+
+    def old_endpoint(transport, args):
+        if ":" in pivot_endpoint:
+            # pivot_endpoint is of the form <ip>:<port>
+            # we want to replace both old host and port
+            old = f"{args.URI_HOST}:{old_port(transport, args)}"
+        else:
+            # pivot endpoint is of the form <ip>
+            # we only want to replace the host part and keep the port
+            old = args.URI_HOST
+
+        return old
+
+
+    if not pivot_endpoint:
+        return callbacks
+
+    modifiedCallbacks = callbacks.copy()
+    for transport in callbacks:
+        old = old_endpoint(transport, args)
+        modifiedCallbacks[transport] = callbacks[transport].replace(old, pivot_endpoint, 1)
+
+    return modifiedCallbacks


### PR DESCRIPTION
Add support to load PowerHub via pivot endpoints (forwarded ports).
This is useful if you want to load PowerHub from targets that cannot reach the PowerHub host directly (and without needing to restart PowerHub to change the listener).

Without pivot option:
<img width="1260" height="814" alt="image" src="https://github.com/user-attachments/assets/97b05316-edad-41ec-b05c-faa38cfa1599" />

With pivot option (download cradle and callbacks are modified):
<img width="1264" height="839" alt="image" src="https://github.com/user-attachments/assets/c7e1a948-d68b-4c45-b069-baa3e44a12f3" />
